### PR TITLE
Update readme with cd + preview info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Once created, this project can be easily and quickly deployed to Vercel from the
 First, install the dependencies by cloning the repo and running one of the following commands, depending on your current setup:
 ```bash
 git clone https://github.com/ButterCMS/nextjs-starter-buttercms.git
+cd nextjs-starter-buttercms
 npm install # or yarn install
 ```
 
@@ -44,3 +45,7 @@ Deploy your Butterized proof of concept app and spread your love of Butter.
 Deploy your Next.js app using Vercel, the creators of Next.js. With the click of a button, you'll create a copy of your starter project in your Git provider account, instantly deploy it, and institute a full content workflow connected to your ButterCMS account. Smooth.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Fnextjs-starter-buttercms&env=NEXT_PUBLIC_BUTTER_CMS_API_KEY&envDescription=Your%20ButterCMS%20API%20Token&envLink=https%3A%2F%2Fbuttercms.com%2Fsettings%2F&project-name=nextjs-starter-buttercms&repo-name=nextjs-starter-buttercms&redirect-url=https%3A%2F%2Fbuttercms.com%2Fonboarding%2Fvercel-starter-deploy-callback%2F&production-deploy-hook=Deploy%20Triggered%20from%20ButterCMS&demo-title=ButterCMS%20Next.js%20Starter&demo-description=Fully%20integrated%20with%20your%20ButterCMS%20account&demo-url=https%3A%2F%2Fnextjs-starter-buttercms.vercel.app%2F&demo-image=https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY&repository-name=nextjs-starter-buttercms)
+
+## 5) Previewing
+
+Your starter project is automatically configured to show draft changes saved in your Butter account when run locally or deployed to a hosting provider. To disable this behavior, set the following value in your .env file: PREVIEW=false.


### PR DESCRIPTION
Just adding the cd and preview lines to the readme.

Note: 

I assumed PREVIEW=false in the env would work as the relevant line from lib/api.js is below:

```
const previewSetting = process.env.PREVIEW
// make preview mode by default
const preview = previewSetting === "true" || previewSetting === undefined ? 1 : 0

try {
  butter = Butter(process.env.NEXT_PUBLIC_BUTTER_CMS_API_KEY, preview);
}
```
I took that to mean that setting PREVIEW=false would return value of zero, disabling preview, but did not test it. Let me know if you want me to test it.