### PR TITLE
Make Anchor Buttons Display block

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -195,6 +195,12 @@ p {
   overflow: hidden;
 }
 
+a.main-btn {
+    display: block;
+    max-width:400px;
+    margin-bottom: 5px;
+}
+
 .main-btn:hover {
   color: #fff;
 }


### PR DESCRIPTION
Making the anchor buttons display block forces subsequent content to a new line. ON the home page it looks odd to have the "Need an account?" text beside the "Update this page in Butter" button. Now they should be on two separate lines.

Before
![CleanShot 2022-02-19 at 10 46 59](https://user-images.githubusercontent.com/5391915/154810296-172f12cb-3272-4c13-a9fb-e9ba1aa03138.png)


After
![CleanShot 2022-02-19 at 10 46 38](https://user-images.githubusercontent.com/5391915/154810279-72b36b28-ce84-4f8a-b83f-bbed5c919b41.png)
