### PR TITLE
Add heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@ Live Demo: https://nextjs-starter-buttercms.vercel.app/
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Fnextjs-starter-buttercms&env=NEXT_PUBLIC_BUTTER_CMS_API_KEY&envDescription=Your%20ButterCMS%20API%20Token&envLink=https%3A%2F%2Fbuttercms.com%2Fsettings%2F&project-name=nextjs-starter-buttercms&repo-name=nextjs-starter-buttercms&redirect-url=https%3A%2F%2Fbuttercms.com%2Fonboarding%2Fvercel-starter-deploy-callback%2F&production-deploy-hook=Deploy%20Triggered%20from%20ButterCMS&demo-title=ButterCMS%20Next.js%20Starter&demo-description=Fully%20integrated%20with%20your%20ButterCMS%20account&demo-url=https%3A%2F%2Fnextjs-starter-buttercms.vercel.app%2F&demo-image=https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY&repository-name=nextjs-starter-buttercms)
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/ButterCMS/nextjs-starter-buttercms&env%5BNEXT_PUBLIC_BUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings)
 
 This Next.js starter project fully integrates with dynamic sample content from your ButterCMS account, including main menu, pages, blog posts, categories, and tags, all with a beautiful, custom theme with already-implemented search functionality. All of the included sample content is automatically created in your account dashboard when you sign up for a free trial of ButterCMS.
 
-Once created, this project can be easily and quickly deployed to Vercel from the CLI ([see instructions below](#deploy-on-vercel))
-
-
+A copy of this starter project can be easily and quickly deployed to Vercel or Heroku with the click of a button.
 ## 1) Installation
 
 First, install the dependencies by cloning the repo and running one of the following commands, depending on your current setup:
@@ -38,13 +37,12 @@ Congratulations! Your starter project is now live: [http://localhost:3000](http:
 
 ## 4) Deploy
 
-Deploy your Butterized proof of concept app and spread your love of Butter.
-
-###  Vercel
-
-Deploy your Next.js app using Vercel, the creators of Next.js. With the click of a button, you'll create a copy of your starter project in your Git provider account, instantly deploy it, and institute a full content workflow connected to your ButterCMS account. Smooth.
+Deploy your Butterized proof of concept app and spread your love of Butter, to either 
+Vercel, the creators of Next.js, or to Heroku. With the click of a button, you'll create a copy of our starter project in your Git provider account, instantly deploy it, and institute a full content workflow connected to your ButterCMS account. Smooth.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FButterCMS%2Fnextjs-starter-buttercms&env=NEXT_PUBLIC_BUTTER_CMS_API_KEY&envDescription=Your%20ButterCMS%20API%20Token&envLink=https%3A%2F%2Fbuttercms.com%2Fsettings%2F&project-name=nextjs-starter-buttercms&repo-name=nextjs-starter-buttercms&redirect-url=https%3A%2F%2Fbuttercms.com%2Fonboarding%2Fvercel-starter-deploy-callback%2F&production-deploy-hook=Deploy%20Triggered%20from%20ButterCMS&demo-title=ButterCMS%20Next.js%20Starter&demo-description=Fully%20integrated%20with%20your%20ButterCMS%20account&demo-url=https%3A%2F%2Fnextjs-starter-buttercms.vercel.app%2F&demo-image=https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY&repository-name=nextjs-starter-buttercms)
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/ButterCMS/nextjs-starter-buttercms&env%5BNEXT_PUBLIC_BUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings)
 
 ## 5) Previewing
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,18 @@
+{
+    "name": "ButterCMS NextJS Starter Project ",
+    "description": "Drop-in proof-of-concept NextJs app, fully integrated with your ButterCMS account.",
+    "repository": "https://github.com/ButterCMS/nextjs-starter-buttercms",
+    "logo": "https://cdn.buttercms.com/r0tGK8xFRti2iRKBJ0eY",
+    "keywords": ["Next.js", "buttercms", "cms", "blog"],
+    "buildpacks": [
+        {
+          "url": "heroku/nodejs"
+        }
+    ],
+    "env": {
+        "NEXT_PUBLIC_BUTTER_CMS_API_KEY": {
+            "description": "The API token of your ButterCMS account",
+            "value": ""
+        }
+    }
+}


### PR DESCRIPTION
Trello Card: https://trello.com/c/by0cH7rw/1479-add-heroku-deploy-for-gatsby-and-nextjs

Add Heroku button to NextJS starter. 

This is the first of a few different PRs that will be linked to the same trello card, as this information will also need to be added to docs + onboarding for NextJS, and then the same aspects will be duplicated for GatsbyJS.

Note: To test button's functionality, right click on the button and get the URL it redirects to [https://heroku.com/deploy?template=https://github.com/ButterCMS/nextjs-starter-buttercms&env%5BNEXT_PUBLIC_BUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings](https://heroku.com/deploy?template=https://github.com/ButterCMS/nextjs-starter-buttercms&env%5BNEXT_PUBLIC_BUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings) and replace the github repo url with this branch's url: https://github.com/ButterCMS/nextjs-starter-buttercms/tree/1479-add-heroku-deploy-for-gatsby-and-nextjs.

This will give you the following link, which will pull from this branch vs master.
[https://heroku.com/deploy?template=https://github.com/ButterCMS/nextjs-starter-buttercms/tree/1479-add-heroku-deploy-for-gatsby-and-nextjs&env%5BNEXT_PUBLIC_BUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings](https://heroku.com/deploy?template=https://github.com/ButterCMS/nextjs-starter-buttercms/tree/1479-add-heroku-deploy-for-gatsby-and-nextjs&env%5BNEXT_PUBLIC_BUTTER_CMS_API_KEY%5D=check%20https://buttercms.com/settings)

 This will launch the URL using this branch instead of main.